### PR TITLE
Address UBSAN messages reported by kernel

### DIFF
--- a/aq_nic.c
+++ b/aq_nic.c
@@ -326,7 +326,8 @@ static void aq_nic_polling_timer_cb(struct timer_list *t)
 	unsigned int i = 0U;
 
 	for (i = 0U, aq_vec = self->aq_vec[0];
-		self->aq_vecs > i; ++i, aq_vec = self->aq_vec[i])
+		self->aq_vecs > i; ++i)
+        aq_vec = self->aq_vec[i];
 		aq_vec_isr(i, (void *)aq_vec);
 
 	mod_timer(&self->polling_timer, jiffies +
@@ -589,7 +590,8 @@ int aq_nic_start(struct aq_nic_s *self)
 		goto err_exit;
 
 	for (i = 0U, aq_vec = self->aq_vec[0];
-		self->aq_vecs > i; ++i, aq_vec = self->aq_vec[i]) {
+		self->aq_vecs > i; ++i) {
+        aq_vec = self->aq_vec[i];
 		err = aq_vec_start(aq_vec);
 		if (err < 0)
 			goto err_exit;
@@ -649,7 +651,8 @@ int aq_nic_start(struct aq_nic_s *self)
 			  AQ_CFG_POLLING_TIMER_INTERVAL);
 	} else {
 		for (i = 0U, aq_vec = self->aq_vec[0];
-			self->aq_vecs > i; ++i, aq_vec = self->aq_vec[i]) {
+			self->aq_vecs > i; ++i) {
+            aq_vec = self->aq_vec[i];
 			err = aq_pci_func_alloc_irq(self, i, self->ndev->name,
 						    aq_vec_isr, aq_vec,
 						    aq_vec_get_affinity_mask(aq_vec));
@@ -1084,8 +1087,8 @@ u64 *aq_nic_get_stats(struct aq_nic_s *self, u64 *data)
 
 	for (tc = 0U; tc < self->aq_nic_cfg.tcs; tc++) {
 		for (i = 0U, aq_vec = self->aq_vec[0];
-		     aq_vec && self->aq_vecs > i;
-		     ++i, aq_vec = self->aq_vec[i]) {
+		     aq_vec && self->aq_vecs > i; ++i) {
+            aq_vec = self->aq_vec[i];
 			data += count;
 			count = aq_vec_get_sw_stats(aq_vec, tc, data);
 		}
@@ -1567,8 +1570,11 @@ int aq_nic_stop(struct aq_nic_s *self)
 	aq_ptp_irq_free(self);
 
 	for (i = 0U, aq_vec = self->aq_vec[0];
-		self->aq_vecs > i; ++i, aq_vec = self->aq_vec[i])
+		self->aq_vecs > i; ++i)
+    {
+        aq_vec = self->aq_vec[i];
 		aq_vec_stop(aq_vec);
+    }
 
 	aq_ptp_ring_stop(self);
 

--- a/aq_nic.c
+++ b/aq_nic.c
@@ -326,9 +326,10 @@ static void aq_nic_polling_timer_cb(struct timer_list *t)
 	unsigned int i = 0U;
 
 	for (i = 0U, aq_vec = self->aq_vec[0];
-		self->aq_vecs > i; ++i)
-        aq_vec = self->aq_vec[i];
-		aq_vec_isr(i, (void *)aq_vec);
+		self->aq_vecs > i; ++i) {
+		aq_vec = self->aq_vec[i];
+		aq_vec_isr(i, (void *) aq_vec);
+	}
 
 	mod_timer(&self->polling_timer, jiffies +
 		  AQ_CFG_POLLING_TIMER_INTERVAL);
@@ -591,7 +592,7 @@ int aq_nic_start(struct aq_nic_s *self)
 
 	for (i = 0U, aq_vec = self->aq_vec[0];
 		self->aq_vecs > i; ++i) {
-        aq_vec = self->aq_vec[i];
+		aq_vec = self->aq_vec[i];
 		err = aq_vec_start(aq_vec);
 		if (err < 0)
 			goto err_exit;
@@ -652,7 +653,7 @@ int aq_nic_start(struct aq_nic_s *self)
 	} else {
 		for (i = 0U, aq_vec = self->aq_vec[0];
 			self->aq_vecs > i; ++i) {
-            aq_vec = self->aq_vec[i];
+			aq_vec = self->aq_vec[i];
 			err = aq_pci_func_alloc_irq(self, i, self->ndev->name,
 						    aq_vec_isr, aq_vec,
 						    aq_vec_get_affinity_mask(aq_vec));
@@ -1088,7 +1089,7 @@ u64 *aq_nic_get_stats(struct aq_nic_s *self, u64 *data)
 	for (tc = 0U; tc < self->aq_nic_cfg.tcs; tc++) {
 		for (i = 0U, aq_vec = self->aq_vec[0];
 		     aq_vec && self->aq_vecs > i; ++i) {
-            aq_vec = self->aq_vec[i];
+			aq_vec = self->aq_vec[i];
 			data += count;
 			count = aq_vec_get_sw_stats(aq_vec, tc, data);
 		}
@@ -1570,11 +1571,10 @@ int aq_nic_stop(struct aq_nic_s *self)
 	aq_ptp_irq_free(self);
 
 	for (i = 0U, aq_vec = self->aq_vec[0];
-		self->aq_vecs > i; ++i)
-    {
-        aq_vec = self->aq_vec[i];
+		self->aq_vecs > i; ++i) {
+		aq_vec = self->aq_vec[i];
 		aq_vec_stop(aq_vec);
-    }
+	}
 
 	aq_ptp_ring_stop(self);
 


### PR DESCRIPTION
Address UBSAN messages reported by kernel like the following:
```
UBSAN: array-index-out-of-bounds in ~/AQtion/aq_nic.c:1571:48
[ 1455.064437] index 8 is out of range for type 'aq_vec_s *[8]'
```
Avoid UB by not dereferencing the array unless the for loop condition is true.