### PR TITLE
Drop the weight argument from netif_napi_add for kernel 6.1

### DIFF
--- a/aq_ptp.c
+++ b/aq_ptp.c
@@ -2127,8 +2127,7 @@ int aq_ptp_init(struct aq_nic_s *aq_nic, unsigned int idx_ptp_vec, unsigned int 
 	atomic_set(&aq_ptp->offset_egress, 0);
 	atomic_set(&aq_ptp->offset_ingress, 0);
 
-	netif_napi_add(aq_nic_get_ndev(aq_nic), &aq_ptp->napi,
-		       aq_ptp_poll, AQ_CFG_NAPI_WEIGHT);
+	netif_napi_add(aq_nic_get_ndev(aq_nic), &aq_ptp->napi, aq_ptp_poll);
 
 	aq_ptp->idx_ptp_vector = idx_ptp_vec;
 	aq_ptp->idx_gpio_vector = idx_ext_vec;

--- a/aq_vec.c
+++ b/aq_vec.c
@@ -123,8 +123,7 @@ struct aq_vec_s *aq_vec_alloc(struct aq_nic_s *aq_nic, unsigned int idx,
 	cpumask_set_cpu(self->aq_ring_param.cpu,
 			&self->aq_ring_param.affinity_mask);
 
-	netif_napi_add(aq_nic_get_ndev(aq_nic), &self->napi,
-		       aq_vec_poll, AQ_CFG_NAPI_WEIGHT);
+	netif_napi_add(aq_nic_get_ndev(aq_nic), &self->napi, aq_vec_poll);
 
 err_exit:
 	return self;


### PR DESCRIPTION
Fixed #44 

ref. https://github.com/torvalds/linux/commit/b48b89f9c189d24eb5e2b4a0ac067da5a24ee86d#diff-3900aacc8a16ceb4c46b358fd64df5951289a8c2ead2a1fc05c77df4d90f8916