### PR TITLE
make 6.2.0 compilable

### DIFF
--- a/aq_dash.c
+++ b/aq_dash.c
@@ -449,8 +449,11 @@ error_exit:
 		RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7, 2)
 static int aq_dash_pre_doit(struct genl_ops *ops, struct sk_buff *skb,
 			      struct genl_info *info)
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+static int aq_dash_pre_doit(const struct genl_info *ops, struct sk_buff *skb,
+			      struct genl_info *info)
 #else
-static int aq_dash_pre_doit(const struct genl_ops *ops, struct sk_buff *skb,
+static int aq_dash_pre_doit(const struct genl_split_ops *ops, struct sk_buff *skb,
 			      struct genl_info *info)
 #endif
 {

--- a/aq_dash.c
+++ b/aq_dash.c
@@ -450,7 +450,7 @@ error_exit:
 static int aq_dash_pre_doit(struct genl_ops *ops, struct sk_buff *skb,
 			      struct genl_info *info)
 #elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
-static int aq_dash_pre_doit(const struct genl_info *ops, struct sk_buff *skb,
+static int aq_dash_pre_doit(const struct genl_ops *ops, struct sk_buff *skb,
 			      struct genl_info *info)
 #else
 static int aq_dash_pre_doit(const struct genl_split_ops *ops, struct sk_buff *skb,

--- a/aq_macsec.c
+++ b/aq_macsec.c
@@ -293,8 +293,10 @@ static int aq_mdo_dev_open(struct macsec_context *ctx)
 	struct aq_nic_s *nic = netdev_priv(ctx->netdev);
 	int ret = 0;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	if (netif_carrier_ok(nic->ndev))
 		ret = aq_apply_secy_cfg(nic, ctx->secy);
@@ -307,8 +309,10 @@ static int aq_mdo_dev_stop(struct macsec_context *ctx)
 	struct aq_nic_s *nic = netdev_priv(ctx->netdev);
 	int i;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	for (i = 0; i < AQ_MACSEC_MAX_SC; i++) {
 		if (nic->macsec_cfg->txsc_idx_busy & BIT(i))
@@ -469,8 +473,10 @@ static int aq_mdo_add_secy(struct macsec_context *ctx)
 	if (txsc_idx == AQ_MACSEC_MAX_SC)
 		return -ENOSPC;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	cfg->sc_sa = sc_sa;
 	cfg->aq_txsc[txsc_idx].hw_sc_idx = aq_to_hw_sc_idx(txsc_idx, sc_sa);
@@ -495,8 +501,7 @@ static int aq_mdo_upd_secy(struct macsec_context *ctx)
 	if (txsc_idx < 0)
 		return -ENOENT;
 
-	if (ctx->prepare)
-		return 0;
+
 
 	if (netif_carrier_ok(nic->ndev) && netif_running(secy->netdev))
 		ret = aq_set_txsc(nic, txsc_idx);
@@ -546,8 +551,10 @@ static int aq_mdo_del_secy(struct macsec_context *ctx)
 	struct aq_nic_s *nic = netdev_priv(ctx->netdev);
 	int ret = 0;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	if (!nic->macsec_cfg)
 		return 0;
@@ -608,8 +615,10 @@ static int aq_mdo_add_txsa(struct macsec_context *ctx)
 	if (txsc_idx < 0)
 		return -EINVAL;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	aq_txsc = &cfg->aq_txsc[txsc_idx];
 	set_bit(ctx->sa.assoc_num, &aq_txsc->tx_sa_idx_busy);
@@ -638,8 +647,10 @@ static int aq_mdo_upd_txsa(struct macsec_context *ctx)
 	if (txsc_idx < 0)
 		return -EINVAL;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	aq_txsc = &cfg->aq_txsc[txsc_idx];
 	if (netif_carrier_ok(nic->ndev) && netif_running(secy->netdev))
@@ -688,8 +699,10 @@ static int aq_mdo_del_txsa(struct macsec_context *ctx)
 	if (txsc_idx < 0)
 		return -EINVAL;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	ret = aq_clear_txsa(nic, &cfg->aq_txsc[txsc_idx], ctx->sa.assoc_num,
 			    AQ_CLEAR_ALL);
@@ -787,8 +800,10 @@ static int aq_mdo_add_rxsc(struct macsec_context *ctx)
 	if (rxsc_idx >= rxsc_idx_max)
 		return -ENOSPC;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	cfg->aq_rxsc[rxsc_idx].hw_sc_idx = aq_to_hw_sc_idx(rxsc_idx,
 							   cfg->sc_sa);
@@ -816,8 +831,10 @@ static int aq_mdo_upd_rxsc(struct macsec_context *ctx)
 	if (rxsc_idx < 0)
 		return -ENOENT;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	if (netif_carrier_ok(nic->ndev) && netif_running(ctx->secy->netdev))
 		ret = aq_set_rxsc(nic, rxsc_idx);
@@ -883,8 +900,10 @@ static int aq_mdo_del_rxsc(struct macsec_context *ctx)
 	if (rxsc_idx < 0)
 		return -ENOENT;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	if (netif_carrier_ok(nic->ndev))
 		clear_type = AQ_CLEAR_ALL;
@@ -959,8 +978,10 @@ static int aq_mdo_add_rxsa(struct macsec_context *ctx)
 	if (rxsc_idx < 0)
 		return -EINVAL;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	aq_rxsc = &nic->macsec_cfg->aq_rxsc[rxsc_idx];
 	set_bit(ctx->sa.assoc_num, &aq_rxsc->rx_sa_idx_busy);
@@ -989,8 +1010,10 @@ static int aq_mdo_upd_rxsa(struct macsec_context *ctx)
 	if (rxsc_idx < 0)
 		return -EINVAL;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	if (netif_carrier_ok(nic->ndev) && netif_running(secy->netdev))
 		ret = aq_update_rxsa(nic, cfg->aq_rxsc[rxsc_idx].hw_sc_idx,
@@ -1040,8 +1063,10 @@ static int aq_mdo_del_rxsa(struct macsec_context *ctx)
 	if (rxsc_idx < 0)
 		return -EINVAL;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	ret = aq_clear_rxsa(nic, &cfg->aq_rxsc[rxsc_idx], ctx->sa.assoc_num,
 			    AQ_CLEAR_ALL);
@@ -1055,8 +1080,7 @@ static int aq_mdo_get_dev_stats(struct macsec_context *ctx)
 	struct aq_macsec_common_stats *stats = &nic->macsec_cfg->stats;
 	struct aq_hw_s *hw = nic->aq_hw;
 
-	if (ctx->prepare)
-		return 0;
+
 
 	aq_get_macsec_common_stats(hw, stats);
 
@@ -1084,9 +1108,10 @@ static int aq_mdo_get_tx_sc_stats(struct macsec_context *ctx)
 	if (txsc_idx < 0)
 		return -ENOENT;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
-
+#endif
 	aq_txsc = &nic->macsec_cfg->aq_txsc[txsc_idx];
 	stats = &aq_txsc->stats;
 	aq_get_txsc_stats(hw, aq_txsc->hw_sc_idx, stats);
@@ -1117,9 +1142,10 @@ static int aq_mdo_get_tx_sa_stats(struct macsec_context *ctx)
 	if (txsc_idx < 0)
 		return -EINVAL;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
-
+#endif
 	aq_txsc = &cfg->aq_txsc[txsc_idx];
 	sa_idx = aq_txsc->hw_sc_idx | ctx->sa.assoc_num;
 	stats = &aq_txsc->tx_sa_stats[ctx->sa.assoc_num];
@@ -1157,10 +1183,10 @@ static int aq_mdo_get_rx_sc_stats(struct macsec_context *ctx)
 	rxsc_idx = aq_get_rxsc_idx_from_rxsc(cfg, ctx->rx_sc);
 	if (rxsc_idx < 0)
 		return -ENOENT;
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
-
+#endif
 	aq_rxsc = &cfg->aq_rxsc[rxsc_idx];
 	for (i = 0; i < MACSEC_NUM_AN; i++) {
 		if (!test_bit(i, &aq_rxsc->rx_sa_idx_busy))
@@ -1207,8 +1233,10 @@ static int aq_mdo_get_rx_sa_stats(struct macsec_context *ctx)
 	if (rxsc_idx < 0)
 		return -EINVAL;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	aq_rxsc = &cfg->aq_rxsc[rxsc_idx];
 	stats = &aq_rxsc->rx_sa_stats[ctx->sa.assoc_num];
@@ -1452,7 +1480,9 @@ static void aq_check_txsa_expiration(struct aq_nic_s *nic)
 			}
 
 			tx_sa = rcu_dereference_bh(secy->tx_sc.sa[an]);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 			macsec_pn_wrapped((struct macsec_secy *)secy, tx_sa);
+#endif
 		}
 	}
 

--- a/aq_ptp.c
+++ b/aq_ptp.c
@@ -2127,8 +2127,13 @@ int aq_ptp_init(struct aq_nic_s *aq_nic, unsigned int idx_ptp_vec, unsigned int 
 	atomic_set(&aq_ptp->offset_egress, 0);
 	atomic_set(&aq_ptp->offset_ingress, 0);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	netif_napi_add(aq_nic_get_ndev(aq_nic), &aq_ptp->napi,
 		       aq_ptp_poll, AQ_CFG_NAPI_WEIGHT);
+#else
+	netif_napi_add(aq_nic_get_ndev(aq_nic), &aq_ptp->napi,
+		       aq_ptp_poll);
+#endif
 
 	aq_ptp->idx_ptp_vector = idx_ptp_vec;
 	aq_ptp->idx_gpio_vector = idx_ext_vec;

--- a/aq_vec.c
+++ b/aq_vec.c
@@ -122,10 +122,13 @@ struct aq_vec_s *aq_vec_alloc(struct aq_nic_s *aq_nic, unsigned int idx,
 
 	cpumask_set_cpu(self->aq_ring_param.cpu,
 			&self->aq_ring_param.affinity_mask);
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	netif_napi_add(aq_nic_get_ndev(aq_nic), &self->napi,
 		       aq_vec_poll, AQ_CFG_NAPI_WEIGHT);
-
+#else
+	netif_napi_add(aq_nic_get_ndev(aq_nic), &self->napi,
+		       aq_vec_poll);
+#endif
 err_exit:
 	return self;
 }


### PR DESCRIPTION
Default ubuntu 23.04 release's kernel 6.2.0-20-generic misses a lot of the symbol, the dmesg shows below.
```bash
[    1.446775] atlantic: no symbol version for module_layout
[    1.446835] atlantic: module verification failed: signature and/or required key missing - tainting kernel
[    1.446842] atlantic: disagrees about version of symbol __tracepoint_xdp_exception
[    1.446843] atlantic: Unknown symbol __tracepoint_xdp_exception (err -22)
[    1.446862] atlantic: Unknown symbol kmem_cache_alloc_trace (err -2)
[    1.446868] atlantic: Unknown symbol kmalloc_order_trace (err -2)
[    1.446882] atlantic: Unknown symbol del_timer_sync (err -2)
[    1.446886] atlantic: Unknown symbol macsec_pn_wrapped (err -2)
[    1.446889] atlantic: Unknown symbol cpu_number (err -2)
[    1.446890] atlantic: Unknown symbol __preempt_count (err -2)
```

I remove the symbol and add conditional compilation for macsec_context *ctx->prepare not exists in 6.2.0 and different function signature for macsec_pn_wrapped and aq_dash_pre_doit.
